### PR TITLE
Fix `get_comment_count` template tag

### DIFF
--- a/django_comments_tree/models.py
+++ b/django_comments_tree/models.py
@@ -159,6 +159,13 @@ class CommentManager(MP_NodeManager):
                                                          model=model))
         return self.for_content_types(content_types, **kwargs)
 
+    def for_object(self, object_id, content_type, site):
+        """
+        :return: queryset of the given object
+        """
+        qs = self.for_content_types([content_type], site)
+        return qs.filter(assoc__object_id=object_id)
+
     def for_content_types(self,
                           content_types: List[str],
                           site: int = None) -> Optional[models.QuerySet]:

--- a/django_comments_tree/tests/test_templatetags.py
+++ b/django_comments_tree/tests/test_templatetags.py
@@ -22,7 +22,7 @@ class GetCommentCountTestCase(DjangoTestCase):
         self.article_2 = Article.objects.create(
             title="October", slug="october", body="What I did on October...")
         self.day_in_diary = Diary.objects.create(body="About Today...")
-        
+
     def test_get_comment_count_for_one_model(self):
         thread_test_step_1(self.article_1)
         t = ("{% load comments_tree %}"
@@ -38,7 +38,22 @@ class GetCommentCountTestCase(DjangoTestCase):
              "   for tests.article tests.diary %}"
              "{{ varname }}")
         self.assertEqual(Template(t).render(Context()), '3')
-        
+
+    def test_get_comment_count(self):
+        """
+            {% get_comment_count for [object] as [varname]  %}
+            {% get_comment_count for [app].[model] [object_id] as [varname]  %}
+        """
+
+        t = ("{% load comments_tree %}"
+             "{% get_comment_count for article as varname %}"
+             "{{ varname }}")
+        thread_test_step_1(self.article_1)
+        self.assertEqual(Template(t).render(Context({'article': self.article_1})), '2')
+        thread_test_step_2(self.article_1)
+        self.assertEqual(Template(t).render(Context({'article': self.article_1})), '4')
+        thread_test_step_3(self.article_1)
+        self.assertEqual(Template(t).render(Context({'article': self.article_1})), '5')
 
 class LastCommentsTestCase(DjangoTestCase):
     def setUp(self):


### PR DESCRIPTION
Created a new `CommentCountNode` to query from related association field
Added a test case for `get_comment_count`